### PR TITLE
feat: add support for user certificate in an authenticated environment

### DIFF
--- a/schema-pusher/Chart.yaml
+++ b/schema-pusher/Chart.yaml
@@ -1,8 +1,8 @@
 ---
 apiVersion: v2
 name: schema-pusher
-version: 1.1.0
-appVersion: 0.2.2
+version: 1.2.0
+appVersion: 0.3.0
 description: A Helm chart for pushing schema files to Red Hat's Service Registry
 type: application
 keywords:

--- a/schema-pusher/templates/pod.yaml
+++ b/schema-pusher/templates/pod.yaml
@@ -10,10 +10,17 @@ spec:
   - name: config
     configMap:
       name: {{ .Release.Name }}-configmap
-  {{- if .Values.kafka.certificate }}
-  - name: kafka-certificate
+  {{- if .Values.kafka.certificates }}
+  {{- if .Values.kafka.certificates.server }}
+  - name: kafka-server-certificate
     secret:
-      secretName: {{ .Values.kafka.certificate.secret }}
+      secretName: {{ .Values.kafka.certificates.server.secret }}
+  {{- end }}
+  {{- if .Values.kafka.certificates.user }}
+  - name: kafka-user-certificate
+    secret:
+      secretName: {{ .Values.kafka.certificates.user.secret }}
+  {{- end }}
   {{- end }}
   restartPolicy: Never
   containers:
@@ -31,15 +38,29 @@ spec:
         --strategy $(cat /config/naming.strategy)
         $topic_args
         --content $(cat /config/encoded.archive | base64 -w 0 -)
-      {{- if .Values.kafka.certificate }}
-        --certificate $(cat /config/kafka.certificate/ca.crt | base64 -w 0 -)
+      {{- if .Values.kafka.certificates }}
+      {{- if .Values.kafka.certificates.server }}
+        --truststore $(cat /config/kafka.certificates.server/ca.p12 | base64 -w 0 -)
+        --truststorePassword $(cat /config/kafka.certificates.server/ca.password)
+      {{- end }}
+      {{- if .Values.kafka.certificates.user }}
+        --keystore $(cat /config/kafka.certificates.user/user.p12 | base64 -w 0 -)
+        --keystorePassword $(cat /config/kafka.certificates.user/user.password)
+      {{- end }}
       {{- end }}
     volumeMounts:
     - name: config
       mountPath: /config
       readOnly: true
-    {{- if .Values.kafka.certificate }}
-    - name: kafka-certificate
-      mountPath: /config/kafka.certificate
+    {{- if .Values.kafka.certificates }}
+    {{- if .Values.kafka.certificates.server }}
+    - name: kafka-server-certificate
+      mountPath: /config/kafka.certificates.server
       readOnly: true
+    {{- end }}
+    {{- if .Values.kafka.certificates.user }}
+    - name: kafka-user-certificate
+      mountPath: /config/kafka.certificates.user
+      readOnly: true
+    {{- end }}
     {{- end }}

--- a/schema-pusher/values.schema.json
+++ b/schema-pusher/values.schema.json
@@ -22,16 +22,47 @@
           "description": "Bootstrap URL",
           "$ref": "#/$defs/url"
         },
-        "certificate": {
+        "certificates": {
           "type": "object",
-          "description": "Certificate information",
-          "required": [
-            "secret"
+          "description": "Certificates information",
+          "oneOff": [
+            {
+              "required": [
+                "server"
+              ]
+            },
+            {
+              "required": [
+                "user"
+              ]
+            }
           ],
           "properties": {
-            "secret": {
-              "type": "string",
-              "description": "The name of the kafka cluster certificate secret with a ca.crt key in it"
+            "server": {
+              "type": "object",
+              "description": "Server certificate information",
+              "required": [
+                "secret"
+              ],
+              "properties": {
+                "secret": {
+                  "type": "string",
+                  "description": "The name of the secret containing the server p12 store"
+                }
+              }
+            },
+            "user": {
+              "type": "object",
+              "description": "User certificate information",
+              "required": [
+                "secret"
+              ],
+              "properties": {
+                "secret": {
+                  "type": "string",
+                  "description": "The name of the secret containing the user p12 store"
+                }
+              }
             }
           }
         }

--- a/schema-pusher/values.yaml
+++ b/schema-pusher/values.yaml
@@ -2,14 +2,19 @@
 kafka:
   # replace <kafka-bootstrap-url-goes-here> with the kafka bootstrap route
   bootstrap: https://<kafka-bootstrap-url-goes-here>:443/
-  # if the kafka server is secured with a self-signed certificate, add the secret name that holds the ca.crt key
-  # certificate:
-    # secret: my-kafka-cluster-cluster-ca-cert
+  # optionally specify a secrets containing a p12 and a password data entries to use with the kafka producer
+  # a server secret containing a ca.p12 and ca.password data entries to be used as a truststore
+  # a user secret containing a user.p12 and user.password data entries to be used as a keystore
+  certificates:
+    server:
+      secret: kafka-cluster-ca-cert
+    user:
+      secret: kafka-user-cert
 
 service:
-  # replace <registry-service> with the internal apicurio service and <namespace> with the namespace it's on
-  # you can also use the route instead
-  registry: http://<registry-service>.<namespace>.svc.cluster.local:8080
+  # replace <service-registry-url-goes-here> with red hat's service registry instance
+  # you can also use the service name internally inside your cluster
+  registry: http://<service-registry-url-goes-here>/
 
 naming:
   # this can be topic/record/topic_record, but for multiple topics, only topic_record is allowed


### PR DESCRIPTION
truststore and keystore are now a pkcs12 type stores.

BREAKING CHANGE: removed the value 'kafka.certificate.secret',
replcaed it with 'kafka.certificates.server' and
'kafka.certificates.user'.
